### PR TITLE
move token to headers

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -8,17 +8,18 @@ const crypto = require('crypto')
 // Thank you so much H4O, i hate when people use unnecessary dependencies (and fix proto pollution in silly ways)
 const JSONB = require('when-json-met-bigint').JSONB({strict: true, protoAction: 'ignore', constructorAction: 'ignore'})
 
-function validatePublicToken(req, res, token) {
+function validatePublicToken(req, res) {
     // TODO: write this in the future to enable outsiders to access "private" endpoints
-    return validateToken(req, res, token)
+    return validateToken(req, res)
 }
 
-function validateToken(req, res, token) {
+function validateToken(req, res) {
     if (!Object.hasOwn(ipTokens, req.remoteExpanded)) {
         doError(res, 401)
         return false
     }
     let [expected, creation] = ipTokens[req.remoteExpanded]
+    let token = req.header('x-token')
     // check token FIRST... gives less info away
     if (!expected || typeof expected != 'string' || !token || typeof token != 'string' || expected !== token) {
         doError(res, 401)
@@ -163,7 +164,13 @@ api.all('/', (req, res) => {
 
 // Returns cached count of all documents in player details collection, cached on first call of the day
 api.get('/playerCount', async (req, res) => {
-    res.json(await database.playerCountCache())
+    if (!!req.header('x-token')) {
+        if (!validatePublicToken(req, res))
+            return 0;
+        res.json(await database.playerCount())
+    } else {
+        res.json(await database.playerCountCache())
+    }
 })
 
 // List players that match the given name
@@ -191,16 +198,12 @@ api.get('/player/ignoreList/:uuid', async (req, res) => {
  * Token access point
  *
  * Exchange for new token
- * {
- *     exchange: String
- * }
+ * X-Exchange-Token: exchange
  *
  * Generate new token
- * {
- *     refresh: String
- * }
+ * X-Refresh-Token: token
  */
-api.post('/token', async (req, res) => {
+api.get('/token', async (req, res) => {
 
     // Small note: We can theoretically return a mix of 4XX codes, however this would give away information to potential
     // intruders that they've gotten past certain checkpoints, so we cannot do that.
@@ -215,7 +218,8 @@ api.post('/token', async (req, res) => {
     if (!Object.hasOwn(ipTokens, req.remoteExpanded))
         return doError(res, 401)
 
-    let {exchange, refresh} = req.body
+    let exchange = req.header('x-exchange-token')
+    let refresh = req.header('x-refresh-token')
 
     // At least one is required, but not both, and it must be string
     if ((!!exchange == !!refresh) || (typeof exchange != 'string' && typeof refresh != 'string'))
@@ -292,21 +296,6 @@ api.post('/token', async (req, res) => {
 /* Private API endpoints, requiring valid token */
 
 /**
- * Counts all documents in player details collection
- *
- * {
- *     token: String
- * }
- */
-api.post('/playerCount', async (req, res) => {
-    let {token} = req.body
-    if (!validatePublicToken(req, res, token))
-        return 0;
-
-    res.json(await database.playerCount())
-})
-
-/**
  * Retrieve player stats by key(s)
  *
  * Both "stat" and "stats" are aliases. They are provided for readability, and
@@ -314,15 +303,14 @@ api.post('/playerCount', async (req, res) => {
  * will take priority if it isn't `null`.
  *
  * {
- *     token: String
  *     uuid: String
  *     stat?: String, String[]
  *     stats?: String, String[]
  * }
  */
 api.post('/player/getStats', async (req, res) => {
-    let {token, uuid, stat, stats} = req.body
-    if (!validatePublicToken(req, res, token))
+    let {uuid, stat, stats} = req.body
+    if (!validatePublicToken(req, res))
         return 0;
 
     res.json(await database.playerStatsGet(uuid, stat ?? stats))
@@ -344,7 +332,6 @@ api.post('/player/getStats', async (req, res) => {
  * Save chat message
  *
  * {
- *     token: String
  *     chat: {
  *         time: Number?
  *         uuid: String
@@ -358,8 +345,8 @@ api.post('/player/getStats', async (req, res) => {
  * }
  */
 api.post('/chat', async (req, res) => {
-    let {token, chat} = req.body
-    if (!validateToken(req, res, token))
+    let {chat} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.chatSave(chat))
@@ -369,15 +356,14 @@ api.post('/chat', async (req, res) => {
  * Get chats
  *
  * {
- *     token: String
  *     uuid: String
  *     since: Number
  *     offset: Number?
  * }
  */
 api.post('/chat/get', async (req, res) => {
-    let {token, uuid, since, offset} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, since, offset} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.chatGet(uuid, since, offset))
@@ -387,7 +373,6 @@ api.post('/chat/get', async (req, res) => {
  * Send message to discord webhook
  *
  * {
- *     token: String
  *     kind: String
  *     name: String?
  *     avatar: String?
@@ -395,8 +380,8 @@ api.post('/chat/get', async (req, res) => {
  * }
  */
 api.post('/discord/webhook', async (req, res) => {
-    let {token, kind, name, avatar, message} = req.body
-    if (!validateToken(req, res, token))
+    let {kind, name, avatar, message} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await discord.webhookSend(kind, name, avatar, message))
@@ -406,13 +391,12 @@ api.post('/discord/webhook', async (req, res) => {
  * Log to database
  *
  * {
- *     token: String
  *     message: String
  * }
  */
 api.post('/log', async (req, res) => {
-    let {token, message} = req.body
-    if (!validateToken(req, res, token))
+    let {message} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.logSave(message))
@@ -422,7 +406,6 @@ api.post('/log', async (req, res) => {
  * Save mail
  *
  * {
- *     token: String
  *     to: String
  *     from: String
  *     origin: String
@@ -430,8 +413,8 @@ api.post('/log', async (req, res) => {
  * }
  */
 api.post('/mail', async (req, res) => {
-    let {token, to, from, origin, message} = req.body
-    if (!validateToken(req, res, token))
+    let {to, from, origin, message} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.mailSave(to, from, origin, message))
@@ -441,14 +424,13 @@ api.post('/mail', async (req, res) => {
  * Mark mail as deleted
  *
  * {
- *     token: String
  *     uuid: String
  *     id: String
  * }
  */
 api.post('/mail/delete', async (req, res) => {
-    let {token, uuid, id} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, id} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.mailDelete(uuid, id))
@@ -458,14 +440,13 @@ api.post('/mail/delete', async (req, res) => {
  * Get mail by 'from' value
  *
  * {
- *     token: String
  *     uuid: String
  *     offset: Number?
  * }
  */
 api.post('/mail/from', async (req, res) => {
-    let {token, uuid, offset} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, offset} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.mailGet('from', uuid, offset))
@@ -475,14 +456,13 @@ api.post('/mail/from', async (req, res) => {
  * Mark mail as read
  *
  * {
- *     token: String
  *     uuid: String
  *     id: String
  * }
  */
 api.post('/mail/read', async (req, res) => {
-    let {token, uuid, id} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, id} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.mailRead(uuid, id))
@@ -492,14 +472,13 @@ api.post('/mail/read', async (req, res) => {
  * Get mail by 'to' value
  *
  * {
- *     token: String
  *     uuid: String
  *     offset: Number?
  * }
  */
 api.post('/mail/to', async (req, res) => {
-    let {token, uuid, offset} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, offset} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.mailGet('to', uuid, offset))
@@ -509,14 +488,13 @@ api.post('/mail/to', async (req, res) => {
  * Mark mail as NOT read
  *
  * {
- *     token: String
  *     uuid: String
  *     id: String
  * }
  */
 api.post('/mail/unread', async (req, res) => {
-    let {token, uuid, id} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, id} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.mailRead(uuid, id, false))
@@ -526,15 +504,14 @@ api.post('/mail/unread', async (req, res) => {
  * Mute/ unmute a player, or retrieve mute time.
  *
  * {
- *     token: String
  *     uuid: String
  *     time: null, Number, '?'
  * }
  *
  */
 api.post('/moderation/mute', async (req, res) => {
-    let {token, uuid, time} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, time} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.moderationMute(uuid, time))
@@ -544,7 +521,6 @@ api.post('/moderation/mute', async (req, res) => {
  * Set player connection
  *
  * {
- *     token: String
  *     uuid: String
  *     type: String
  *     pair: "content", "hash", "token"
@@ -553,8 +529,8 @@ api.post('/moderation/mute', async (req, res) => {
  * }
  */
 api.post('/player/connection', async (req, res) => {
-    let {token, uuid, type, pair, value, expire} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, type, pair, value, expire} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerConnectionSet(uuid, type, pair, value, expire))
@@ -564,14 +540,13 @@ api.post('/player/connection', async (req, res) => {
  * Find player by connection
  *
  * {
- *     token: String
  *     type: String
  *     content: String
  * }
  */
 api.post('/player/connection/find', async (req, res) => {
-    let {token, type, content} = req.body
-    if (!validateToken(req, res, token))
+    let {type, content} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerConnectionFind(type, content))
@@ -581,15 +556,14 @@ api.post('/player/connection/find', async (req, res) => {
  * Get player connection
  *
  * {
- *     token: String
  *     uuid: String
  *     type: String
  *     pair: "content", "hash", "token"
  * }
  */
 api.post('/player/connection/get', async (req, res) => {
-    let {token, uuid, type, pair} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, type, pair} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerConnectionGet(uuid, type, pair))
@@ -599,15 +573,14 @@ api.post('/player/connection/get', async (req, res) => {
  * Set player persistent data
  *
  * {
- *     token: String
  *     uuid: String
  *     name: String
  *     value: String?, Number?
  * }
  */
 api.post('/player/data', async (req, res) => {
-    let {token, uuid, name, value} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, name, value} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerDataSet(uuid, name, value))
@@ -617,14 +590,13 @@ api.post('/player/data', async (req, res) => {
  * Get player persistent data
  *
  * {
- *     token: String
  *     uuid: String
  *     name: String
  * }
  */
 api.post('/player/data/get', async (req, res) => {
-    let {token, uuid, name} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, name} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerDataGet(uuid, name))
@@ -634,7 +606,6 @@ api.post('/player/data/get', async (req, res) => {
  * Add or remove an ignore for a player
  *
  * {
- *     token: String
  *     uuid: String
  *     other: String
  *     ignore: true
@@ -642,8 +613,8 @@ api.post('/player/data/get', async (req, res) => {
  *
  */
 api.post('/player/ignore', async (req, res) => {
-    let {token, uuid, other, ignore} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, other, ignore} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerIgnoreSet(uuid, other, ignore))
@@ -653,14 +624,13 @@ api.post('/player/ignore', async (req, res) => {
  * Login player
  *
  * {
- *     token: String
  *     uuid: String
  *     name: String
  * }
  */
 api.post('/player/login', async (req, res) => {
-    let {token, uuid, name} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, name} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerLogin(uuid, name))
@@ -670,13 +640,12 @@ api.post('/player/login', async (req, res) => {
  * Logout player
  *
  * {
- *     token: String
  *     uuid: String
  * }
  */
 api.post('/player/logout', async (req, res) => {
-    let {token, uuid} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerLogout(uuid))
@@ -690,7 +659,6 @@ api.post('/player/logout', async (req, res) => {
  * will take priority if it isn't `null`.
  *
  * {
- *     token: String
  *     uuid: String
  *     stat?: String, String[]
  *     stats?: String, String[]
@@ -698,8 +666,8 @@ api.post('/player/logout', async (req, res) => {
  * }
  */
 api.post('/player/stat', async (req, res) => {
-    let {token, uuid, stat, stats, delta} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, stat, stats, delta} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerStatsUpdate(uuid, stat ?? stats, delta))
@@ -714,15 +682,14 @@ api.post('/player/stat', async (req, res) => {
  * will take priority if it isn't `null`.
  *
  * {
- *     token: String
  *     uuid: String
  *     stat?: String, String[]
  *     stats?: String, String[]
  * }
  */
 api.post('/player/stat/get', async (req, res) => {
-    let {token, uuid, stat, stats} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, stat, stats} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerStatsGet(uuid, stat ?? stats))
@@ -733,7 +700,6 @@ api.post('/player/stat/get', async (req, res) => {
  * Set player name style
  *
  * {
- *     token: String
  *     uuid: String
  *     style: {
  *         bold?: true
@@ -745,8 +711,8 @@ api.post('/player/stat/get', async (req, res) => {
  * }
  */
 api.post('/player/style', async (req, res) => {
-    let {token, uuid, style} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, style} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerNameStyleSet(uuid, style))
@@ -760,7 +726,6 @@ api.post('/player/style', async (req, res) => {
  * "wallet" will take priority if it isn't `null`.
  *
  * {
- *     token: String
  *     uuid: String
  *     wallet?: String, String[]
  *     wallets?: String, String[]
@@ -770,8 +735,8 @@ api.post('/player/style', async (req, res) => {
  * }
  */
 api.post('/player/wallet', async (req, res) => {
-    let {token, uuid, wallet, wallets, delta, allowNegative, failIfPartial} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, wallet, wallets, delta, allowNegative, failIfPartial} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerWalletUpdate(uuid, wallet ?? wallets, delta, allowNegative, failIfPartial))
@@ -785,15 +750,14 @@ api.post('/player/wallet', async (req, res) => {
  * "wallet" will take priority if it isn't `null`.
  *
  * {
- *     token: String
  *     uuid: String
  *     wallet?: String, String[]
  *     wallets?: String, String[]
  * }
  */
 api.post('/player/wallet/get', async (req, res) => {
-    let {token, uuid, wallet, wallets} = req.body
-    if (!validateToken(req, res, token))
+    let {uuid, wallet, wallets} = req.body
+    if (!validateToken(req, res))
         return 0;
 
     res.json(await database.playerWalletGet(uuid, wallet ?? wallets))

--- a/testing.js
+++ b/testing.js
@@ -38,6 +38,8 @@ async function main() {
         //playerConnectionFind('discord', '210270460313731072')
         //playerConnectionGet("61408852-e247-4f91-8f4c-1e3fdbcd64fe", "discord", 'token')
         //playerConnectionSet("61408852-e247-4f91-8f4c-1e3fdbcd64fe", "discord", "content", "210270460313731072", 31556889864403199n) // 210270460313731072
+        //playerConnectionSet('61408852-e247-4f91-8f4c-1e3fdbcd64fe', 'discord', 'hash', '')
+        //playerConnectionSet('61408852-e247-4f91-8f4c-1e3fdbcd64fe', 'discord', 'content', null)
         //playerDataGet("61408852-e247-4f91-8f4c-1e3fdbcd64fe", 'scoreboard')
         //playerDataSet("61408852-e247-4f91-8f4c-1e3fdbcd64fe", 'mega', null)
         //playerIgnoreSet("61408852-e247-4f91-8f4c-1e3fdbcd64fe", "aabc4b20-c14a-4ead-94fa-5d594042a57d", false)


### PR DESCRIPTION
token validation, exchange, and refreshing now uses headers
I can see why APIs use tokens in the header now, it's easier to implement and supports *any* request method out of the box.
Also, the "standard" for using `X-` prefixes on custom headers is oddly reminiscent of early-internet "cool" usernames that use Xs.